### PR TITLE
Added visual min_brightness support to ui-element

### DIFF
--- a/color-lite-card.js
+++ b/color-lite-card.js
@@ -21,7 +21,9 @@ if(state){
 		const imageURLCId = this.config.color_image;				
 		var rgbval = state.attributes.rgb_color;			
 		var hsval = state.attributes.hs_color;			
-		var hsar = "";			
+		var hsar = "";
+		var min_bright = (this.config.min_brightness * 2.5);
+		var bright = state.attributes.brightness;
 		if (hsval) {
 			if (rgbval != "255,255,255") {				
 				var hsar = ' hue-rotate(' + hsval[0] + 'deg)';			
@@ -30,8 +32,11 @@ if(state){
 				}
 			}
 		}		
-		var bbritef = state.attributes.brightness;	
-		var bbrite = (bbritef / 205);	
+		var bbritef = bright;	
+		if (min_bright > bright) {
+			bbritef = min_bright;
+		}
+		var bbrite = (bbritef / 205);
 	
 		this.content.innerHTML = `	
 <!-- Custom Lite Card for x${rgbval}x -->	


### PR DESCRIPTION
I have added a new attribute called "min_brightness" to the custom element in the ui, my changes in the code take this min_brightness over the actual brightness if the later is lower.

Reason being, that I have non-hue lamps which at 1% brightness are effectively as bright as hue lamps having 15-20% brightness.
This change reflect the real life experience better on the floorplan. 