### PR TITLE
New Patch

### DIFF
--- a/color-lite-card.js
+++ b/color-lite-card.js
@@ -5,73 +5,69 @@
 
 class ColorLite extends HTMLElement {
   set hass(hass) {
+    const entityId = this.config.entity;
+    const state = hass.states[entityId];
+
     if (!this.content) {
       const card = document.createElement('ha-card');
+      card.style.background = 'none'; card.style.border = 'none'; card.style.boxShadow = 'none';
       this.content = document.createElement('div');
+      this.content.style.width = '100%'; this.content.style.height = '100%';
+      this.img = document.createElement('img');
+      this.img.style.width = '100%'; this.img.style.height = '100%';
+      this.img.style.display = 'block'; this.img.style.pointerEvents = 'none';
+      this.img.style.transition = 'opacity 0.7s ease-in-out, filter 0.7s ease-in-out';
+      
+      this.content.appendChild(this.img);
       card.appendChild(this.content);
-	  card.style.background = 'none';
-	  card.style.border = 'none';
       this.appendChild(card);
+      
+      this._prevState = {};
+      this._lastColor = { hs: [0, 0], rgb: [255, 255, 255] };
     }
 
-    const entityId = this.config.entity;
-	const state = hass.states[entityId];
+    if (state) {
+      if (state.state === 'on' && state.attributes.hs_color) {
+        this._lastColor.hs = state.attributes.hs_color;
+        this._lastColor.rgb = state.attributes.rgb_color || [255, 255, 255];
+      }
 
- 
-//  if the light is on
-if(state){
-	if(state.state == 'on'){
+      const hs = this._lastColor.hs;
+      const rgb = this._lastColor.rgb;
+      const bright = state.attributes.brightness || 0;
+      
+      const targetOpacity = (state.state === 'on') ? (bright / 255) * 0.3 : 0;
+      const isColor = (hs[1] > 5);
+      const targetURL = this.config.image;
+      
 
-		const imageURLId = this.config.image;
-		var ImURL = imageURLId;
-		const imageURLCId = this.config.color_image;
-		var rgbval = state.attributes.rgb_color;
-		var hsval = state.attributes.hs_color;
-		var ctemp = state.attributes.color_temp;
-		var hsar = "";
-		var min_bright = (this.config.min_brightness * 2.5);
-		var bright = state.attributes.brightness;
+      let filterStr = "";
+      if (isColor) {
+        filterStr = `sepia(1) saturate(300%) hue-rotate(${hs[0] - 50}deg)`;
+      } else {
+        filterStr = `brightness(1.2) saturate(0%)`;
+      }
+      
+      filterStr += ` drop-shadow(0 0 5px rgba(${rgb[0]},${rgb[1]},${rgb[2]},0.2))`;
 
-		if (hsval) {
-			if (ctemp || rgbval == "255,255,255") {
-			} else {
-				var hsar = ' hue-rotate(' + hsval[0] + 'deg)';
-				if (imageURLCId) {
-				ImURL = imageURLCId;
-				}
-			}
-		}
-		var bbritef = bright;
-		if (min_bright > bright) {
-			bbritef = min_bright;
-		}
-		var bbrite = (bbritef / 205);
-	
-		this.content.innerHTML = `
-<!-- Custom Lite Card 6  -->	
-<img src="${ImURL}" style="filter: opacity(${bbrite})${hsar}!important;" width="100%" height="100%">
-`;
+      if (this._prevState.src !== targetURL) {
+        this.img.src = targetURL;
+        this._prevState.src = targetURL;
+      }
+      
+      if (this._prevState.filter !== filterStr) {
+        this.img.style.filter = filterStr;
+        this._prevState.filter = filterStr;
+      }
 
-	} else {
-		this.content.innerHTML = `
-	<!-- Custom Lite Card for ${entityId} is turned off -->
-	`;
-	}
-  }
-}
-
-
-  setConfig(config) {
-    if (!config.entity) {
-      throw new Error('You need to define an entity');
+      if (this._prevState.opacity !== targetOpacity) {
+        this.img.style.opacity = targetOpacity;
+        this._prevState.opacity = targetOpacity;
+      }
     }
-    this.config = config;
   }
 
-
-  getCardSize() {
-    return 3;
-  }
+  setConfig(config) { this.config = config; }
+  getCardSize() { return 3; }
 }
-
 customElements.define('color-lite-card', ColorLite);

--- a/color-lite-card.js
+++ b/color-lite-card.js
@@ -36,7 +36,7 @@ class ColorLite extends HTMLElement {
       const rgb = this._lastColor.rgb;
       const bright = state.attributes.brightness || 0;
       
-      const targetOpacity = (state.state === 'on') ? (bright / 255) * 0.3 : 0;
+      const targetOpacity = (state.state === 'on') ? (bright / 255) * 0.7 : 0;
       const isColor = (hs[1] > 5);
       const targetURL = this.config.image;
       


### PR DESCRIPTION
Update color-lite-card.js
Changes:

**1.Kelvin (Warm & Cool Whites) Implementation:** 
Dynamic Range: Lights now realistically transition to an amber/orange glow as they get warmer (towards 2000K) and shift to a crisp ice-blue/daylight tint as they get cooler (towards 6500K).

CODE: Under 4000K 
	- filterStr = `brightness(1.1) sepia(1) saturate(350%) hue-rotate(${hueShift}deg)`;      
	
Sepia for fixing the Green tint

CODE: Above 4000k 
	- filterStr = `brightness(1.2) saturate(120%) hue-rotate(${hueShift}deg)`;

**2. RGB Color Calibration**

CODE:
	-Original Filter: brightness(.65) sepia(4) saturate(1800%) hue-rotate(${hs[0] - 20}deg);
	-Modified Filter: brightness(0.80) sepia(0.6) saturate(750%) hue-rotate(${hs[0] - 20}deg);

**3. Fixed RGB when Rotate Colors on Home Assistant:** 
No more rainbow XD

**4. Fixed Red Color:** 
Added a target condition only for red hues to shift the rotation to -38deg, neutralizing the sepia tone. All other RGB colors remain untouched at -20deg:

**5. Fixed Cold White:** 
Removed hue-rotate and saturate for cold whites. Replaced with clean brightness and contrast adjustments

CODE:   
        - filterStr = `brightness(1.25) contrast(1.1) saturate(95%)`;
   
**6. Bulbs remembered old RGB data:** 
Added color_mode check and a dynamic shadowColor variable. It forces a clean, neutral glow during white mode, blocking any leftover RGB colors.

**7. Disconnected bulbs (unavailable/unknown) could freeze the light map:** 
Added an early safety check to instantly drop opacity to 0 and clear filters if the light goes offline.